### PR TITLE
More reliable checking whether Method Title is empty

### DIFF
--- a/oik-weightcountry-shipping.php
+++ b/oik-weightcountry-shipping.php
@@ -254,7 +254,7 @@ function init_oik_shipping() {
      */
     function set_countrygroup_title( $rate ) {
 		  //bw_trace2();
-      if ( isset( $rate[3] ) ) {
+      if ( isset( $rate[3] ) && $rate[3] != "" ) {
         $title = $rate[3];
       } else {
         $title = $this->title;


### PR DESCRIPTION
I had a situation where we were getting the "There are no shipping methods available. Please double check your address, or contact us if you need any help." message even though we had a shipping method set up with OIK. This happened because WooCommerce demands that you have a label for the shipping method.

In OIK we don't have a shipping method for every rate - we have `7.99|69|0|` rather than `7.99|69|0|Regular Shipping`. But because OIK isn't checking that reliably whether the string is empty, it actually thought that there was a name after the last |. And so it was setting the label to the name, e.g. to an empty string.

This patch fixes the problem.
